### PR TITLE
Fix social media preview images for event pages

### DIFF
--- a/src/routes/events-calendar/+page.svelte
+++ b/src/routes/events-calendar/+page.svelte
@@ -7,7 +7,7 @@
 	<meta property="og:type" content="website" />
 	<meta property="og:title" content="Events Calendar • Connect Bern" />
 	<meta property="og:description" content="Discover upcoming events in Bern. Weekly and special meetups by Connect Bern and friends." />
-	<meta property="og:image" content="https://connectbern.ch/icons/connect-bern-logo-white.png" />
+	<meta property="og:image" content="https://connectbern.ch/images/connect-and-cheers-1.jpg" />
 
 	<!-- Twitter -->
 	<meta name="twitter:card" content="summary_large_image" />
@@ -15,7 +15,7 @@
 	<meta property="twitter:url" content="https://connectbern.ch/events-calendar" />
 	<meta name="twitter:title" content="Events Calendar • Connect Bern" />
 	<meta name="twitter:description" content="Discover upcoming events in Bern. Weekly and special meetups by Connect Bern and friends." />
-	<meta name="twitter:image" content="https://connectbern.ch/icons/connect-bern-logo-white.png" />
+	<meta name="twitter:image" content="https://connectbern.ch/images/connect-and-cheers-1.jpg" />
 </svelte:head>
 
 <script>

--- a/src/routes/events/connect-and-cheers/+page.svelte
+++ b/src/routes/events/connect-and-cheers/+page.svelte
@@ -1,5 +1,21 @@
 <svelte:head>
 	<title>Connect & Cheers • Events • Connect Bern</title>
+	<meta name="description" content="Every Friday evening at PROGR Turnhalle – relaxed drinks, chats and connections. Part of the Connect Bern community project." />
+
+	<!-- Open Graph -->
+	<meta property="og:url" content="https://connectbern.ch/events/connect-and-cheers" />
+	<meta property="og:type" content="website" />
+	<meta property="og:title" content="Connect & Cheers • Connect Bern" />
+	<meta property="og:description" content="Every Friday evening at PROGR Turnhalle – relaxed drinks, chats and connections. Part of the Connect Bern community project." />
+	<meta property="og:image" content="https://connectbern.ch/images/connect-and-cheers-1.jpg" />
+
+	<!-- Twitter -->
+	<meta name="twitter:card" content="summary_large_image" />
+	<meta property="twitter:domain" content="connectbern.ch" />
+	<meta property="twitter:url" content="https://connectbern.ch/events/connect-and-cheers" />
+	<meta name="twitter:title" content="Connect & Cheers • Connect Bern" />
+	<meta name="twitter:description" content="Every Friday evening at PROGR Turnhalle – relaxed drinks, chats and connections. Part of the Connect Bern community project." />
+	<meta name="twitter:image" content="https://connectbern.ch/images/connect-and-cheers-1.jpg" />
 </svelte:head>
 
 <script>


### PR DESCRIPTION
- Add comprehensive Open Graph and Twitter card meta tags to Connect & Cheers event page
- Replace white logo with actual event image (connect-and-cheers-1.jpg) in events-calendar page
- This fixes the issue where social media previews appeared as white when sharing links