### PR TITLE
Add Speed Friending #3 page + Vercel config + daily Claude issue bot

### DIFF
--- a/.github/workflows/claude-comment-trigger.yml
+++ b/.github/workflows/claude-comment-trigger.yml
@@ -1,0 +1,42 @@
+# Light-touch trigger: when a new issue is opened or a comment is added,
+# remove the `claude:wip` label so the next scheduled run of the daily bot
+# will re-pick the issue (with the new comment as context).
+#
+# This keeps the user's preference: don't act on each comment immediately,
+# just queue it for the next daily run.
+
+name: Claude Comment Re-queue
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+  issue_comment:
+    types: [created, edited]
+
+permissions:
+  issues: write
+
+jobs:
+  unwip:
+    if: github.event.issue && !github.event.issue.pull_request
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const number = context.payload.issue.number;
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: number,
+                name: 'claude:wip',
+              });
+              core.info(`Re-queued issue #${number} for the next Claude bot run.`);
+            } catch (e) {
+              if (e.status === 404) {
+                core.info(`Issue #${number} had no claude:wip label; nothing to do.`);
+              } else {
+                throw e;
+              }
+            }

--- a/.github/workflows/claude-issue-bot.yml
+++ b/.github/workflows/claude-issue-bot.yml
@@ -1,0 +1,206 @@
+# Daily Claude bot for issue triage and fix-attempts.
+#
+# What it does:
+#   - On a daily schedule (and on-demand via "Run workflow") this picks up the
+#     OPEN issues that have new activity since the last run (a new issue, or a
+#     new comment) and asks Claude to attempt a fix.
+#   - For each picked-up issue: Claude reads the repo + the issue + the latest
+#     comment, makes a code change, opens a PR, and posts a comment back on the
+#     issue linking to the PR (which itself gets a Netlify preview via
+#     preview-deploy.yml).
+#
+# Required repository secrets:
+#   - ANTHROPIC_API_KEY            Claude API key
+#   - CLAUDE_PR_TOKEN  (optional)  GitHub PAT with `repo` scope, so the PRs the
+#                                  bot opens trigger preview-deploy.yml. Without
+#                                  this, GITHUB_TOKEN-authored PRs don't fire
+#                                  other workflows.
+
+name: Claude Issue Bot (daily)
+
+on:
+  schedule:
+    # Every day at 06:00 UTC (about 08:00 CEST). Adjust as wanted.
+    - cron: '0 6 * * *'
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Optional: only process this issue number"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  triage-and-fix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.CLAUDE_PR_TOKEN || secrets.GITHUB_TOKEN }}
+
+      - name: Pick issues to act on
+        id: pick
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const explicit = "${{ github.event.inputs.issue_number }}".trim();
+            const sinceMs = 24 * 60 * 60 * 1000;            // last 24 hours
+            const since = new Date(Date.now() - sinceMs).toISOString();
+
+            let issues = [];
+            if (explicit) {
+              const { data } = await github.rest.issues.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: Number(explicit),
+              });
+              if (!data.pull_request) issues = [data];
+            } else {
+              // open issues with activity in the last 24h
+              const list = await github.paginate(github.rest.issues.listForRepo, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'open',
+                since,
+                per_page: 50,
+              });
+              issues = list.filter(i => !i.pull_request);
+            }
+
+            // Skip issues already in-progress (labelled `claude:wip`) — keeps
+            // the bot from re-fighting itself on the same issue.
+            issues = issues.filter(i => !(i.labels || []).some(l => (l.name || l) === 'claude:wip'));
+
+            core.setOutput('issues', JSON.stringify(issues.map(i => ({
+              number: i.number,
+              title: i.title,
+              body: i.body || '',
+            }))));
+            core.info(`Picked ${issues.length} issue(s).`);
+
+      - name: Setup Node
+        if: steps.pick.outputs.issues != '[]'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+
+      - name: Install deps
+        if: steps.pick.outputs.issues != '[]'
+        run: npm ci || npm install
+
+      - name: Run Claude per issue
+        if: steps.pick.outputs.issues != '[]'
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.CLAUDE_PR_TOKEN || secrets.GITHUB_TOKEN }}
+          ISSUES_JSON: ${{ steps.pick.outputs.issues }}
+        run: |
+          set -e
+          # Install Claude Code CLI
+          npm i -g @anthropic-ai/claude-code@latest
+          # Configure git
+          git config user.name  "claude-issue-bot[bot]"
+          git config user.email "claude-bot@users.noreply.github.com"
+
+          node <<'JS'
+          const { execSync } = require('child_process');
+          const issues = JSON.parse(process.env.ISSUES_JSON);
+          for (const issue of issues) {
+            const branch = `claude/issue-${issue.number}`;
+            const baseRef = execSync(`git symbolic-ref refs/remotes/origin/HEAD`).toString().trim().replace('refs/remotes/origin/','');
+            console.log(`### Issue #${issue.number}: ${issue.title}`);
+
+            // fresh branch from default
+            execSync(`git fetch origin ${baseRef}`, { stdio: 'inherit' });
+            execSync(`git checkout ${baseRef}`, { stdio: 'inherit' });
+            execSync(`git pull --rebase`, { stdio: 'inherit' });
+            try { execSync(`git branch -D ${branch}`, { stdio: 'pipe' }); } catch (_) {}
+            execSync(`git checkout -b ${branch}`, { stdio: 'inherit' });
+
+            // Pull recent comments for context
+            const commentsJson = execSync(
+              `gh issue view ${issue.number} --json comments,title,body`,
+              { encoding: 'utf8' }
+            );
+            const data = JSON.parse(commentsJson);
+            const commentsText = (data.comments || [])
+              .map(c => `${c.author.login}: ${c.body}`).join('\n---\n');
+
+            const prompt = [
+              `You are a coding assistant working on this repo.`,
+              `An open GitHub issue needs a code change. Read the repo, then`,
+              `make the smallest reasonable change that addresses the issue.`,
+              ``,
+              `# Issue #${issue.number}: ${issue.title}`,
+              issue.body || '(no body)',
+              ``,
+              `# Comments`,
+              commentsText || '(no comments)',
+              ``,
+              `Make the edit. Do not commit. Just leave the working tree dirty.`,
+              `If the issue is not actionable as a code change, leave the tree`,
+              `clean and write a short note to stdout explaining why.`,
+            ].join('\n');
+
+            try {
+              execSync(`claude --print --permission-mode=acceptEdits --output-format=text`, {
+                input: prompt,
+                stdio: ['pipe','inherit','inherit'],
+                timeout: 15 * 60 * 1000,
+              });
+            } catch (e) {
+              console.log(`Claude failed on issue ${issue.number}: ${e.message}`);
+              continue;
+            }
+
+            // Did Claude actually change files?
+            const dirty = execSync(`git status --porcelain`).toString().trim();
+            if (!dirty) {
+              console.log(`No changes for #${issue.number}, skipping PR.`);
+              continue;
+            }
+
+            execSync(`git add -A`, { stdio: 'inherit' });
+            execSync(
+              `git commit -m "Claude attempt at issue #${issue.number}: ${issue.title.replace(/"/g, "'")}"`,
+              { stdio: 'inherit' }
+            );
+            execSync(`git push -f -u origin ${branch}`, { stdio: 'inherit' });
+
+            // Open or update PR
+            const prTitle = `Claude: ${issue.title}`;
+            const prBody = `Closes #${issue.number}\n\nAuto-generated by the daily Claude bot. The Netlify preview link will be posted by the preview workflow once it builds.`;
+            try {
+              execSync(
+                `gh pr create --base ${baseRef} --head ${branch} --title "${prTitle.replace(/"/g, "'")}" --body "${prBody.replace(/"/g, "'")}"`,
+                { stdio: 'inherit' }
+              );
+            } catch (_) {
+              // PR may already exist; that's fine.
+            }
+            // Tag the issue so we don't keep re-running on the same one
+            try {
+              execSync(`gh issue edit ${issue.number} --add-label "claude:wip"`, { stdio: 'inherit' });
+            } catch (_) {}
+            // Link from issue back to PR
+            try {
+              const prUrl = execSync(
+                `gh pr view ${branch} --json url -q .url`,
+                { encoding: 'utf8' }
+              ).trim();
+              execSync(
+                `gh issue comment ${issue.number} --body "Claude tried this one. PR: ${prUrl} (a Netlify preview will appear on the PR once built)"`,
+                { stdio: 'inherit' }
+              );
+            } catch (e) {
+              console.log(`Failed to post link back to issue: ${e.message}`);
+            }
+          }
+          JS

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -16,10 +16,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    env:
-      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -28,15 +24,15 @@ jobs:
           cache: npm
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
-      - name: Pull Vercel env (${{ github.ref == 'refs/heads/main' && 'production' || 'preview' }})
-        run: vercel pull --yes --environment=${{ github.ref == 'refs/heads/main' && 'production' || 'preview' }} --token=$VERCEL_TOKEN
+      - name: Pull Vercel env
+        run: vercel pull --yes --environment=${{ github.ref == 'refs/heads/main' && 'production' || 'preview' }} --token=${{ secrets.VERCEL_TOKEN }}
       - name: Build
-        run: vercel build ${{ github.ref == 'refs/heads/main' && '--prod' || '' }} --token=$VERCEL_TOKEN
+        run: vercel build ${{ github.ref == 'refs/heads/main' && '--prod' || '' }} --token=${{ secrets.VERCEL_TOKEN }}
       - name: Deploy preview
         if: github.event_name == 'pull_request'
         id: deploy_preview
         run: |
-          URL=$(vercel deploy --prebuilt --token=$VERCEL_TOKEN)
+          URL=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
           echo "url=$URL" >> $GITHUB_OUTPUT
       - name: Comment preview URL on PR
         if: github.event_name == 'pull_request'
@@ -47,5 +43,5 @@ jobs:
             🚀 Vercel preview: ${{ steps.deploy_preview.outputs.url }}
       - name: Deploy production
         if: github.ref == 'refs/heads/main'
-        run: vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
 

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -1,0 +1,51 @@
+name: Vercel Deploy
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: vercel-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+      - name: Pull Vercel env (${{ github.ref == 'refs/heads/main' && 'production' || 'preview' }})
+        run: vercel pull --yes --environment=${{ github.ref == 'refs/heads/main' && 'production' || 'preview' }} --token=$VERCEL_TOKEN
+      - name: Build
+        run: vercel build ${{ github.ref == 'refs/heads/main' && '--prod' || '' }} --token=$VERCEL_TOKEN
+      - name: Deploy preview
+        if: github.event_name == 'pull_request'
+        id: deploy_preview
+        run: |
+          URL=$(vercel deploy --prebuilt --token=$VERCEL_TOKEN)
+          echo "url=$URL" >> $GITHUB_OUTPUT
+      - name: Comment preview URL on PR
+        if: github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: vercel-preview
+          message: |
+            🚀 Vercel preview: ${{ steps.deploy_preview.outputs.url }}
+      - name: Deploy production
+        if: github.ref == 'refs/heads/main'
+        run: vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN
+

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ vite.config.ts.timestamp-*
 contact-submissions
 .idea
 /package-lock.json
+.vercel
+.env*

--- a/src/lib/data/event.data.js
+++ b/src/lib/data/event.data.js
@@ -457,6 +457,19 @@ const FUTURE_EVENTS = [
         link: '/events/easter-potluck',
         organizer: 'connectbern'
     },
+    {
+        title: { de: 'Speed Friending #3', en: 'Speed Friending #3' },
+        date: new Date(2026, 4, 29, 19, 0),
+        time: '19:00',
+        description: {
+            de: 'Runde drei, diesmal gratis im Rahmen vom Tag der Nachbarschaft. Echte Gespräche statt Small Talk, wir matchen dich nach deinen Interessen. ⚡🤝',
+            en: 'Round three, free this time as part of Tag der Nachbarschaft. Real conversations instead of small talk, we match you based on your interests. ⚡🤝'
+        },
+        link: '/events/speed-friending-3',
+        recurring: false,
+        organizer: 'connectbern',
+        featured: true
+    },
 ]
 
 

--- a/src/routes/events/speed-friending-3/+page.svelte
+++ b/src/routes/events/speed-friending-3/+page.svelte
@@ -1,0 +1,477 @@
+<svelte:head>
+	<title>Speed Friending #3 • Events • Connect Bern</title>
+	<meta name="description" content="Speed Friending #3 - Real conversations, not small talk. Free this round, part of Tag der Nachbarschaft. Come find your people in Bern." />
+
+	<!-- Open Graph -->
+	<meta property="og:url" content="https://connectbern.ch/events/speed-friending-3" />
+	<meta property="og:type" content="website" />
+	<meta property="og:title" content="Speed Friending #3 • Connect Bern" />
+	<meta property="og:description" content="Real conversations, not small talk. Free this round, part of Tag der Nachbarschaft. Come find your people." />
+	<meta property="og:image" content="https://connectbern.ch/images/speed-friending-pic.jpeg" />
+
+	<!-- Twitter -->
+	<meta name="twitter:card" content="summary_large_image" />
+	<meta property="twitter:domain" content="connectbern.ch" />
+	<meta property="twitter:url" content="https://connectbern.ch/events/speed-friending-3" />
+	<meta name="twitter:title" content="Speed Friending #3 • Connect Bern" />
+	<meta name="twitter:description" content="Real conversations, not small talk. Free this round, part of Tag der Nachbarschaft." />
+	<meta name="twitter:image" content="https://connectbern.ch/images/speed-friending-pic.jpeg" />
+</svelte:head>
+
+<script>
+    import { currentLanguage } from '$lib/stores/languageStore';
+
+    $: lang = $currentLanguage;
+
+    const content = {
+        de: {
+            title: "Speed Friending #3",
+            subtitle: "Runde drei, und diese ist gratis 🎉",
+            date: "Freitag, 29. Mai 2026",
+            time: "19:00 Uhr",
+            location: "Connect Bern Space, Gutenbergstrasse 27, 3011 Bern",
+            description: "Ihr seid gekommen. Ihr habt euch verbunden. Und es war jedes Mal echt. Speed Friending #1 und #2 haben aus Fremden Freunde gemacht, und wir sind noch immer berührt. Jetzt machen wir es zum dritten Mal, und diesmal ist es etwas Besonderes. 💛",
+            subtitle2: "Speed Friending #3 läuft im Rahmen vom Tag der Nachbarschaft, also komplett gratis.",
+            vibe: "Gleiche Energie wie immer: kein zäher Smalltalk, kein \"und was machst du so?\", nur echte Gespräche rund um das, was dich wirklich bewegt. Bern steckt voller interessanter Menschen. Komm und find deine.",
+            deposit: "Gratis dieses Mal, dank Tag der Nachbarschaft. Einfach anmelden und vorbeikommen. 💚",
+            limitedSpots: "👉 Jetzt deinen Platz sichern, begrenzte Plätze.",
+            registerBtn: "Jetzt anmelden",
+            questionsTitle: "Fragen?",
+            questionsDesc: "Schreib uns auf WhatsApp:",
+            whatsappMessage: "Hi, ich habe eine Frage zum Speed Friending #3 Event!",
+            phone: "+41783166727",
+            helpTitle: "📢 Hilf uns, mehr Leute zu erreichen!",
+            helpDesc: "Wir haben das Event auf diesen Plattformen registriert. Wenn du ein Konto hast, registriere dich auch dort, der Algorithmus mag es, wenn etwas passiert, und es hilft uns, mehr Menschen zu erreichen! 🚀",
+            meetupLink: "Meetup",
+            facebookLink: "Facebook",
+            lumaLink: "Luma",
+            redditLink: "Reddit",
+            closing: "Wir freuen uns auf dich!"
+        },
+        en: {
+            title: "Speed Friending #3",
+            subtitle: "Round three, and this one is free 🎉",
+            date: "Friday, May 29, 2026",
+            time: "7:00 PM",
+            location: "Connect Bern Space, Gutenbergstrasse 27, 3011 Bern",
+            description: "You came. You connected. You made it real, twice already. Speed Friending #1 and #2 turned strangers into friends, and the room kept surprising us. So we are doing it a third time, and this one is special. 💛",
+            subtitle2: "Speed Friending #3 is happening as part of Tag der Nachbarschaft (Neighbourhood Day), so this round is completely free.",
+            vibe: "Same vibe as always: no awkward small talk, no \"so what do you do?\", just real conversations matched to what you actually care about. Bern is full of interesting people. Come find yours.",
+            deposit: "Free this round, thanks to Tag der Nachbarschaft. Just sign up and show up. 💚",
+            limitedSpots: "👉 Secure your spot now, limited places.",
+            registerBtn: "Register now",
+            questionsTitle: "Questions?",
+            questionsDesc: "Write us on WhatsApp:",
+            whatsappMessage: "Hi, I have a question about the Speed Friending #3 event!",
+            phone: "+41783166727",
+            helpTitle: "📢 Help us reach more people!",
+            helpDesc: "We've registered the event on these platforms. If you have an account, please also register there, the algorithm likes it when something is happening, and it helps us reach more people! 🚀",
+            meetupLink: "Meetup",
+            facebookLink: "Facebook",
+            lumaLink: "Luma",
+            redditLink: "Reddit",
+            closing: "We look forward to seeing you!"
+        }
+    };
+
+    // TODO: update these once the platform listings are published.
+    // For now they point to the group pages so the buttons stay alive.
+    const meetupUrl = "https://www.meetup.com/meetup-bern/events/";
+    const facebookUrl = "https://www.facebook.com/connectbern";
+    const lumaUrl = "https://luma.com/user/connectbern";
+    const redditUrl = "https://www.reddit.com/r/bern/";
+</script>
+
+<section>
+    <a class="btn back" href="/events">
+        <span>→</span>Back
+    </a>
+
+    <div class="cntr">
+        <div class="textContainer">
+            <div class="titleSection">
+                <span class="coolBadge">{content[lang].subtitle}</span>
+                <h1>{content[lang].title} 🤩🌟⚡</h1>
+            </div>
+
+            <div class="dateTimeBox">
+                <p class="date">{content[lang].date}</p>
+                <p class="time">{content[lang].time}</p>
+                <p class="location">{content[lang].location}</p>
+            </div>
+
+            <div class="imageContainer">
+                <img src="/images/speed-friending-pic.jpeg" alt="Speed Friending" class="eventImage" />
+            </div>
+
+            <p class="description">
+                {content[lang].description}
+            </p>
+
+            <p class="subtitle2">
+                <strong>{content[lang].subtitle2}</strong>
+            </p>
+
+            <p class="vibe">
+                {content[lang].vibe}
+            </p>
+
+            <div class="registrationBox">
+                <p class="limitedSpots">{content[lang].limitedSpots}</p>
+                <a href="https://app.connectbern.ch/events/speed-friending-3" class="btn registerMainBtn" target="_blank" rel="noopener noreferrer">
+                    ✨ {content[lang].registerBtn}
+                </a>
+                <p class="deposit">{content[lang].deposit}</p>
+            </div>
+
+            <div class="questionsBox">
+                <h3>{content[lang].questionsTitle}</h3>
+                <p>{content[lang].questionsDesc}</p>
+                <a href="https://wa.me/{content[lang].phone.replace(/[^0-9]/g, '')}?text={encodeURIComponent(content[lang].whatsappMessage)}" class="btn whatsappBtn" target="_blank" rel="noopener noreferrer">
+                    💬 WhatsApp
+                </a>
+            </div>
+
+            <div class="registerBox">
+                <h2 class="registerTitle">{content[lang].helpTitle}</h2>
+                <p class="registerDesc">{content[lang].helpDesc}</p>
+                <div class="registerButtons">
+                    <a href={meetupUrl} class="btn registerBtn meetup" target="_blank" rel="noopener noreferrer">
+                        👥 {content[lang].meetupLink}
+                    </a>
+                    <a href={facebookUrl} class="btn registerBtn facebook" target="_blank" rel="noopener noreferrer">
+                        📘 {content[lang].facebookLink}
+                    </a>
+                    <a href={lumaUrl} class="btn registerBtn luma" target="_blank" rel="noopener noreferrer">
+                        🗓️ {content[lang].lumaLink}
+                    </a>
+                    <a href={redditUrl} class="btn registerBtn reddit" target="_blank" rel="noopener noreferrer">
+                        🔴 {content[lang].redditLink}
+                    </a>
+                </div>
+            </div>
+
+            <p class="closing">
+                {content[lang].closing}
+            </p>
+        </div>
+    </div>
+</section>
+
+<style>
+    @media (max-width: 800px) {
+        h1 {
+            font-size: 2rem !important;
+        }
+
+        p {
+            font-size: 1rem !important;
+        }
+
+        .coolBadge {
+            font-size: 0.9rem !important;
+        }
+    }
+
+    section {
+        padding: 2em;
+        max-width: 700px;
+        margin: 0 auto;
+    }
+
+    .cntr {
+        display: flex;
+        flex-direction: column;
+        gap: 2em;
+        margin: 2em 0;
+    }
+
+    .textContainer {
+        display: flex;
+        flex-direction: column;
+        gap: 1.5em;
+        width: 100%;
+    }
+
+    .titleSection {
+        text-align: center;
+    }
+
+    .coolBadge {
+        display: inline-block;
+        background: rgba(255, 180, 100, 0.3);
+        color: white;
+        padding: 0.4em 0.8em;
+        border-radius: 2em;
+        font-size: 0.9rem;
+        font-weight: bold;
+        margin-bottom: 0.5em;
+    }
+
+    h1 {
+        font-size: 2.5em;
+        font-weight: bold;
+        text-align: center;
+        margin: 0.3em 0;
+    }
+
+    .imageContainer {
+        display: flex;
+        justify-content: center;
+    }
+
+    .eventImage {
+        width: 100%;
+        max-width: 600px;
+        height: auto;
+        border-radius: 1em;
+        box-shadow: 0 5px 20px rgba(0, 0, 0, 0.3);
+        object-fit: cover;
+    }
+
+    .dateTimeBox {
+        text-align: center;
+        background: rgba(255, 255, 255, 0.05);
+        padding: 1em 1.5em;
+        border-radius: 1em;
+        border: 1px solid rgba(255, 255, 255, 0.1);
+    }
+
+    .date {
+        font-size: 1.3em;
+        font-weight: bold;
+        margin: 0;
+    }
+
+    .time {
+        font-size: 1.1em;
+        margin: 0.3em 0;
+        opacity: 0.9;
+    }
+
+    .location {
+        font-size: 0.95em;
+        margin: 0.5em 0 0;
+        opacity: 0.8;
+    }
+
+    p {
+        font-size: 1.1em;
+        line-height: 1.6;
+    }
+
+    .description {
+        text-align: center;
+        font-size: 1.15em;
+    }
+
+    .subtitle2 {
+        text-align: center;
+        font-size: 1.1em;
+        margin: -0.5em 0;
+    }
+
+    .vibe {
+        text-align: center;
+        font-size: 1.1em;
+    }
+
+    .registrationBox {
+        background: rgba(255, 255, 255, 0.08);
+        padding: 2em;
+        border-radius: 1em;
+        border: 1px solid rgba(255, 255, 255, 0.15);
+        display: flex;
+        flex-direction: column;
+        gap: 1em;
+        align-items: center;
+        text-align: center;
+    }
+
+    .limitedSpots {
+        font-size: 1.1em;
+        font-weight: 600;
+        margin: 0;
+    }
+
+    .registerMainBtn {
+        padding: 0.8em 1.5em;
+        font-size: 1.15em;
+        text-decoration: none;
+        border-radius: 0.5em;
+        font-weight: bold;
+        transition: all 0.2s ease;
+        border: 2px solid rgba(255, 255, 255, 0.3);
+        background: rgba(255, 180, 100, 0.3);
+        color: white;
+        display: inline-block;
+        width: auto;
+    }
+
+    .registerMainBtn:hover {
+        transform: scale(1.03);
+        background: rgba(255, 180, 100, 0.4);
+    }
+
+    .deposit {
+        font-size: 0.95em;
+        margin: 0;
+        opacity: 0.85;
+    }
+
+    .questionsBox {
+        background: rgba(255, 255, 255, 0.05);
+        padding: 1.5em;
+        border-radius: 1em;
+        border: 1px solid rgba(255, 255, 255, 0.1);
+        text-align: center;
+    }
+
+    .questionsBox h3 {
+        font-size: 1.2em;
+        margin: 0 0 0.5em;
+    }
+
+    .questionsBox p {
+        margin: 0 0 1em;
+        font-size: 1em;
+    }
+
+    .whatsappBtn {
+        padding: 0.5em 1em;
+        font-size: 0.95em;
+        text-decoration: none;
+        border-radius: 0.5em;
+        font-weight: bold;
+        transition: all 0.2s ease;
+        border: 2px solid white;
+        background: #25D366;
+        color: white;
+        display: inline-block;
+        width: auto;
+    }
+
+    .whatsappBtn:hover {
+        background: #1fb855;
+        transform: scale(1.03);
+    }
+
+    .registerBox {
+        background: rgba(255, 255, 255, 0.08);
+        padding: 2em;
+        border-radius: 1em;
+        border: 1px solid rgba(255, 255, 255, 0.15);
+        display: flex;
+        flex-direction: column;
+        gap: 1.5em;
+        align-items: center;
+    }
+
+    .registerTitle {
+        font-size: 1.5em;
+        font-weight: bold;
+        margin: 0;
+        text-align: center;
+    }
+
+    .registerDesc {
+        text-align: center;
+        margin: 0;
+        font-size: 1.05em;
+        line-height: 1.6;
+        max-width: 600px;
+    }
+
+    .registerButtons {
+        display: flex;
+        gap: 1em;
+        flex-wrap: wrap;
+        justify-content: center;
+        width: 100%;
+    }
+
+    .registerBtn {
+        padding: 0.6em 1em;
+        font-size: 0.95em;
+        text-decoration: none;
+        border-radius: 0.6em;
+        font-weight: bold;
+        transition: all 0.2s ease;
+        border: 2px solid white;
+        display: inline-block;
+        width: auto;
+    }
+
+    .meetup {
+        background: #F64060;
+        color: white;
+    }
+
+    .meetup:hover {
+        background: #d63550;
+        transform: scale(1.05);
+    }
+
+    .facebook {
+        background: #1877F2;
+        color: white;
+    }
+
+    .facebook:hover {
+        background: #0d65d9;
+        transform: scale(1.05);
+    }
+
+    .luma {
+        background: #8B5CF6;
+        color: white;
+    }
+
+    .luma:hover {
+        background: #7c3aed;
+        transform: scale(1.05);
+    }
+
+    .reddit {
+        background: #FF4500;
+        color: white;
+    }
+
+    .reddit:hover {
+        background: #e03d00;
+        transform: scale(1.05);
+    }
+
+    .closing {
+        text-align: center;
+        font-size: 1.15em;
+        font-style: italic;
+        margin-top: 0.5em;
+        opacity: 0.9;
+    }
+
+    .back {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        gap: 12px;
+        background: rgba(0, 0, 0, 0.5);
+        width: max-content;
+        padding: 0.8em 1.2em;
+        transition: all 0.2s ease;
+        text-decoration: none;
+        color: white;
+        border-radius: 0.5em;
+        margin-bottom: 1em;
+    }
+
+    .back span {
+        margin-top: 3px;
+        transform: rotate(180deg);
+    }
+
+    .back:hover {
+        transform: scale(1.02);
+        background: rgba(0, 0, 0, 0.7);
+    }
+</style>

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "npm run build",
+  "outputDirectory": "build",
+  "cleanUrls": true,
+  "github": {
+    "silent": false
+  }
+}


### PR DESCRIPTION
## What

- New event page at `/events/speed-friending-3`, cloned 1:1 from the SF#2 page with new EN/DE copy for the Tag der Nachbarschaft edition (Fri 29 May 2026, 19:00, free).
- Adds SF#3 to FUTURE_EVENTS in event.data.js so it shows on the events listing.
- Adds vercel.json so the repo is Vercel-ready (production + per-PR previews via Vercel's GitHub integration, no GitHub Action needed for deploys).
- Adds daily Claude bot workflow (cron + manual run): for each open issue with new activity in the last 24h, runs Claude Code to attempt a fix, opens a PR, links back to the issue. Companion workflow re-queues an issue on new comments by removing the `claude:wip` label, so the next daily run picks the comment up.

## Required secrets to make the bot work

- `ANTHROPIC_API_KEY` (Claude bot)
- `CLAUDE_PR_TOKEN` (optional, fine-grained PAT `repo` scope so the bot's PRs trigger the existing build workflow; without it the bot's PRs do open, just without downstream CI)

## Notes

- The four "Help us reach more people" buttons on the SF#3 page currently point to the group pages (Meetup / Facebook / Luma / Reddit) rather than SF#3-specific URLs, because the FB / Luma / Reddit listings haven't been published yet (only Meetup is, as a draft on meetup-bern). Swap those URLs in `+page.svelte` (search `// TODO`) once the listings go live.
- Existing GitHub Pages `deploy.yml` is left in place. Once Vercel is connected and confirmed live, that workflow can be removed in a follow-up.