### PR TITLE
Claude: Fix Connect & Cheers time (20:00, not 19:00)

### DIFF
--- a/src/lib/data/event.data.js
+++ b/src/lib/data/event.data.js
@@ -293,7 +293,7 @@ const RECURRING_EVENTS = [
         title: { de: 'Connect & Cheers', en: 'Connect & Cheers' },
         date: getNextWeekday(5),
         recurring: 'weekly',
-        time: '19:00',
+        time: '20:00',
         description: {
             de: 'Jeden Freitagabend in der PROGR Turnhalle – entspannter Treff zum Anstoßen, Austauschen und neue Leute kennenlernen. Teil des Community-Projekts Connect Bern.',
             en: 'Every Friday evening at PROGR Turnhalle – relaxed drinks, chats and connections. Part of the Connect Bern community project.'


### PR DESCRIPTION
Closes #48

The events listing showed Connect & Cheers at 19:00, but the event page already said 20:00. Updated `src/lib/data/event.data.js` to match.

Auto-attempted by the daily Claude bot (manual run).