### PR TITLE
Add Speed Friending #3 bubble to main page

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -11,6 +11,13 @@
     <h1>Connect Bern</h1>
     <p class="subtitle">{@html t[language]["description"]}</p>
 
+    <a href="/events/speed-friending-3" class="featured-event-bubble">
+        <span class="bubble-badge">🤩🌟⚡ {language === 'de' ? 'Unser coolstes Event!' : 'Our coolest event!'}</span>
+        <span class="bubble-title">Speed Friending #3</span>
+        <span class="bubble-desc">{language === 'de' ? '29. Mai · Gratis dieses Mal, Tag der Nachbarschaft!' : 'May 29 · Free this round, part of Tag der Nachbarschaft!'}</span>
+        <span class="bubble-cta">{language === 'de' ? 'Mehr erfahren →' : 'Learn more →'}</span>
+    </a>
+
     <div class="menu-section">
         <div class="menu-grid">
             {#each MenuData as item}
@@ -139,6 +146,48 @@
 
 
 <style>
+    /* Featured Event Bubble */
+    .featured-event-bubble {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 0.4rem;
+        padding: 1rem 1.5rem;
+        margin: 0.5rem auto 1.5rem;
+        max-width: 400px;
+        width: 100%;
+        background: rgba(255, 255, 255, 0.08);
+        border: 1px solid rgba(255, 255, 255, 0.15);
+        border-radius: 1rem;
+        text-decoration: none;
+        color: white;
+        box-shadow: 0 4px 15px rgba(0, 0, 0, 0.15);
+        transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+    }
+    .featured-event-bubble:hover {
+        transform: translateY(-3px) scale(1.02);
+        box-shadow: 0 6px 20px rgba(0, 0, 0, 0.25);
+        background: rgba(255, 255, 255, 0.12);
+    }
+    .bubble-badge {
+        font-size: 0.75rem;
+        font-weight: bold;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        background: rgba(255, 180, 100, 0.4);
+        padding: 0.25em 0.75em;
+        border-radius: 1em;
+        color: #fff;
+    }
+    .bubble-title { font-size: 1.4rem; font-weight: bold; margin: 0.1rem 0; }
+    .bubble-desc { font-size: 0.9rem; opacity: 0.95; text-align: center; }
+    .bubble-cta { font-size: 0.85rem; font-weight: 600; margin-top: 0.3rem; opacity: 0.9; }
+    @media (max-width: 768px) {
+        .featured-event-bubble { padding: 0.8rem 1.2rem; margin: 0.5rem 1rem 1rem; }
+        .bubble-title { font-size: 1.2rem; }
+        .bubble-desc { font-size: 0.85rem; }
+    }
+
     .landing {
         min-height: auto;
         display: flex;


### PR DESCRIPTION
Mirrors commit 8aea830 (the SF#2 update). Restores the featured-event-bubble on the landing page right under the subtitle, pointing at /events/speed-friending-3.

The bubble was removed during the landing-page redesign (#122). Adding it back so SF#3 gets the same homepage spotlight SF#1 and SF#2 had.